### PR TITLE
Harvest Add serveUrl to manifest to enable [sc-189159]

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,
+  "serveUrl": "https://apps-cdn.deskpro-service.com/__name__/__version__",
   "targets": [{ "target": "ticket_sidebar", "entrypoint": "index.html" }],
   "settings": {
     "field_mapping": {


### PR DESCRIPTION
Allow serving the app from the CDN instead of always been local. For example: https://apps-cdn.deskpro-service.com/@deskpro-apps/harvest/1.0.26/index.html